### PR TITLE
Add authentication sign-in to login

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
 
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using System.Security.Claims;
 namespace UCDASearches.WebMVC.Controllers
 {
     public class AccountController : Controller
@@ -14,7 +17,7 @@ namespace UCDASearches.WebMVC.Controllers
 
         [ValidateAntiForgeryToken]
         [HttpPost]
-        public IActionResult Login(LoginViewModel model, string? returnUrl = null)
+        public async Task<IActionResult> Login(LoginViewModel model, string? returnUrl = null)
         {
             if (!ModelState.IsValid)
                 return View(model);
@@ -22,6 +25,18 @@ namespace UCDASearches.WebMVC.Controllers
             // TODO: replace with real auth (Identity or your DB)
             if (model.Email == "test@test.com" && model.Password == "123456")
             {
+                var claims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.Name, model.Email)
+                };
+
+                var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+                var principal = new ClaimsPrincipal(identity);
+
+                await HttpContext.SignInAsync(
+                    CookieAuthenticationDefaults.AuthenticationScheme,
+                    principal);
+
                 // return LocalRedirect(returnUrl ?? Url.Action("Index","Home")!);
                 return RedirectToAction("Index", "Search");
             }


### PR DESCRIPTION
## Summary
- create claims for authenticated user and sign in with cookie scheme
- switch login action to asynchronous

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af30f9a13c8330a40664b5a37c8a9a