### PR TITLE
Add previous searches page

### DIFF
--- a/Controllers/PreviousSearchesController.cs
+++ b/Controllers/PreviousSearchesController.cs
@@ -1,0 +1,80 @@
+using System.Data.SqlClient;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using UCDASearches.WebMVC.Models;
+
+namespace UCDASearches.WebMVC.Controllers
+{
+    [Authorize]
+    public class PreviousSearchesController : Controller
+    {
+        private readonly IConfiguration _configuration;
+        public PreviousSearchesController(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index(PreviousSearchesViewModel model)
+        {
+            // Only query when a search is performed
+            if (Request.Query.Count == 0)
+                return View(model);
+
+            var results = new List<PreviousSearch>();
+            var connectionString = _configuration.GetConnectionString("DefaultConnection");
+
+            using var connection = new SqlConnection(connectionString);
+            await connection.OpenAsync();
+
+            var sql = @"SELECT RequestID, UID, VIN, Time_Stamp, Account, Operator, AutoCheck, Lien, History, OOPS
+                     FROM Requests WHERE 1 = 1";
+            var command = new SqlCommand();
+            command.Connection = connection;
+
+            if (!string.IsNullOrWhiteSpace(model.RequestId))
+            {
+                sql += " AND RequestID = @RequestID";
+                command.Parameters.AddWithValue("@RequestID", model.RequestId);
+            }
+            if (!string.IsNullOrWhiteSpace(model.Vin))
+            {
+                sql += " AND VIN = @Vin";
+                command.Parameters.AddWithValue("@Vin", model.Vin);
+            }
+            if (model.FromDate.HasValue)
+            {
+                sql += " AND Time_Stamp >= @FromDate";
+                command.Parameters.AddWithValue("@FromDate", model.FromDate.Value);
+            }
+            if (model.ToDate.HasValue)
+            {
+                sql += " AND Time_Stamp <= @ToDate";
+                command.Parameters.AddWithValue("@ToDate", model.ToDate.Value);
+            }
+
+            command.CommandText = sql;
+
+            using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                results.Add(new PreviousSearch
+                {
+                    RequestID = reader.GetInt32(0),
+                    UID = reader.GetString(1),
+                    Vin = reader.GetString(2),
+                    TimeStamp = reader.GetDateTime(3),
+                    Account = reader.GetString(4),
+                    Operator = reader.GetString(5),
+                    AutoCheck = reader.IsDBNull(6) ? string.Empty : reader.GetString(6),
+                    Lien = reader.IsDBNull(7) ? string.Empty : reader.GetString(7),
+                    History = reader.IsDBNull(8) ? string.Empty : reader.GetString(8),
+                    OOPS = reader.IsDBNull(9) ? string.Empty : reader.GetString(9)
+                });
+            }
+
+            model.Results = results;
+            return View(model);
+        }
+    }
+}

--- a/Models/PreviousSearchesViewModel.cs
+++ b/Models/PreviousSearchesViewModel.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace UCDASearches.WebMVC.Models
+{
+    public class PreviousSearch
+    {
+        public int RequestID { get; set; }
+        public string UID { get; set; } = string.Empty;
+        public string Vin { get; set; } = string.Empty;
+        public DateTime TimeStamp { get; set; }
+        public string Account { get; set; } = string.Empty;
+        public string Operator { get; set; } = string.Empty;
+        public string AutoCheck { get; set; } = string.Empty;
+        public string Lien { get; set; } = string.Empty;
+        public string History { get; set; } = string.Empty;
+        public string OOPS { get; set; } = string.Empty;
+    }
+
+    public class PreviousSearchesViewModel
+    {
+        [Display(Name = "Request #")]
+        public string? RequestId { get; set; }
+
+        public string? Vin { get; set; }
+
+        [DataType(DataType.Date)]
+        [Display(Name = "From")]
+        public DateTime? FromDate { get; set; }
+
+        [DataType(DataType.Date)]
+        [Display(Name = "To")]
+        public DateTime? ToDate { get; set; }
+
+        public List<PreviousSearch> Results { get; set; } = new();
+    }
+}

--- a/UCDASearches.WebMVC.csproj
+++ b/UCDASearches.WebMVC.csproj
@@ -6,4 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+  </ItemGroup>
+
 </Project>

--- a/Views/PreviousSearches/Index.cshtml
+++ b/Views/PreviousSearches/Index.cshtml
@@ -1,0 +1,67 @@
+@model PreviousSearchesViewModel
+@{
+    ViewData["Title"] = "Previous Searches";
+}
+
+<form method="get" class="row g-3 mb-4">
+    <div class="col-md-2">
+        <label asp-for="RequestId" class="form-label"></label>
+        <input asp-for="RequestId" class="form-control" />
+    </div>
+    <div class="col-md-4">
+        <label asp-for="Vin" class="form-label"></label>
+        <input asp-for="Vin" class="form-control" />
+    </div>
+    <div class="col-md-2">
+        <label asp-for="FromDate" class="form-label"></label>
+        <input asp-for="FromDate" class="form-control" />
+    </div>
+    <div class="col-md-2">
+        <label asp-for="ToDate" class="form-label"></label>
+        <input asp-for="ToDate" class="form-control" />
+    </div>
+    <div class="col-md-2 align-self-end">
+        <button class="btn btn-primary w-100">Find</button>
+    </div>
+</form>
+
+@if (Model.Results.Any())
+{
+    <table class="table table-striped align-middle">
+        <thead class="table-primary">
+            <tr>
+                <th>Request #</th>
+                <th>UID</th>
+                <th>VIN</th>
+                <th>Time Stamp</th>
+                <th>Account</th>
+                <th>Operator</th>
+                <th>AutoCheck</th>
+                <th>Lien</th>
+                <th>History</th>
+                <th>OOPS</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var item in Model.Results)
+        {
+            <tr>
+                <td>@item.RequestID</td>
+                <td>@item.UID</td>
+                <td>@item.Vin</td>
+                <td>@item.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                <td>@item.Account</td>
+                <td>@item.Operator</td>
+                <td>@item.AutoCheck</td>
+                <td>@item.Lien</td>
+                <td>@item.History</td>
+                <td>@item.OOPS</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+else if (Context.Request.Query.Any())
+{
+    <div class="alert alert-info">No results found.</div>
+}

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -25,6 +25,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="PreviousSearches" asp-action="Index">Previous Searches</a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=SQLCLA;Database=Searches;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=SQLCLA;Database=Searches;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- Query `Requests` table via classic ADO.NET using RequestID, VIN, and date range filters
- Extend view models and view to surface Request metadata like UID, account and operator
- Point connection string at SQLCLA `Searches` database

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af39f7a7208330b5997e0462ef9cf2