### PR TITLE
Use asynchronous disposal for SQL command

### DIFF
--- a/Controllers/PreviousSearchesController.cs
+++ b/Controllers/PreviousSearchesController.cs
@@ -29,7 +29,7 @@ namespace UCDASearches.WebMVC.Controllers
 
             var sql = @"SELECT RequestID, UID, VIN, Time_Stamp, Account, Operator, AutoCheck, Lien, History, OOPS
                      FROM Requests WHERE 1 = 1";
-            var command = new SqlCommand();
+            await using var command = new SqlCommand();
             command.Connection = connection;
 
             if (!string.IsNullOrWhiteSpace(model.RequestId))


### PR DESCRIPTION
## Summary
- replace synchronous SqlCommand usage with asynchronous disposal in PreviousSearchesController

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af5dfea158833093935560727dddb0