### PR TITLE
Add VIN length and date range validation to previous searches

### DIFF
--- a/Controllers/PreviousSearchesController.cs
+++ b/Controllers/PreviousSearchesController.cs
@@ -17,8 +17,13 @@ namespace UCDASearches.WebMVC.Controllers
         [HttpGet]
         public async Task<IActionResult> Index(PreviousSearchesViewModel model)
         {
-            // Only query when a search is performed
-            if (Request.Query.Count == 0)
+            if (model.FromDate.HasValue && model.ToDate.HasValue && model.FromDate > model.ToDate)
+            {
+                ModelState.AddModelError(string.Empty, "From date must be earlier than or equal to To date.");
+            }
+
+            // Only query when a search is performed or when the model is valid
+            if (!ModelState.IsValid || Request.Query.Count == 0)
                 return View(model);
 
             var results = new List<PreviousSearch>();

--- a/Models/PreviousSearchesViewModel.cs
+++ b/Models/PreviousSearchesViewModel.cs
@@ -6,6 +6,7 @@ namespace UCDASearches.WebMVC.Models
     {
         public int RequestID { get; set; }
         public string UID { get; set; } = string.Empty;
+        [StringLength(17, MinimumLength = 17)]
         public string Vin { get; set; } = string.Empty;
         public DateTime TimeStamp { get; set; }
         public string Account { get; set; } = string.Empty;
@@ -21,6 +22,7 @@ namespace UCDASearches.WebMVC.Models
         [Display(Name = "Request #")]
         public string? RequestId { get; set; }
 
+        [StringLength(17, MinimumLength = 17)]
         public string? Vin { get; set; }
 
         [DataType(DataType.Date)]

--- a/Views/PreviousSearches/Index.cshtml
+++ b/Views/PreviousSearches/Index.cshtml
@@ -4,6 +4,9 @@
 }
 
 <form method="get" class="row g-3 mb-4">
+    <div class="col-12">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    </div>
     <div class="col-md-2">
         <label asp-for="RequestId" class="form-label"></label>
         <input asp-for="RequestId" class="form-control" />


### PR DESCRIPTION
## Summary
- enforce 17-character VINs in previous search models
- validate From/To dates and show errors
- display validation summary on previous searches form

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af5dffd10c8330a3703e37c86a5d2e