### PR TITLE
Add search filters for UID, account, and operator

### DIFF
--- a/Controllers/PreviousSearchesController.cs
+++ b/Controllers/PreviousSearchesController.cs
@@ -42,6 +42,21 @@ namespace UCDASearches.WebMVC.Controllers
                 sql += " AND VIN = @Vin";
                 command.Parameters.AddWithValue("@Vin", model.Vin);
             }
+            if (!string.IsNullOrWhiteSpace(model.Uid))
+            {
+                sql += " AND UID = @Uid";
+                command.Parameters.AddWithValue("@Uid", model.Uid);
+            }
+            if (!string.IsNullOrWhiteSpace(model.Account))
+            {
+                sql += " AND Account = @Account";
+                command.Parameters.AddWithValue("@Account", model.Account);
+            }
+            if (!string.IsNullOrWhiteSpace(model.Operator))
+            {
+                sql += " AND Operator = @Operator";
+                command.Parameters.AddWithValue("@Operator", model.Operator);
+            }
             if (model.FromDate.HasValue)
             {
                 sql += " AND Time_Stamp >= @FromDate";

--- a/Models/PreviousSearchesViewModel.cs
+++ b/Models/PreviousSearchesViewModel.cs
@@ -21,6 +21,12 @@ namespace UCDASearches.WebMVC.Models
         [Display(Name = "Request #")]
         public string? RequestId { get; set; }
 
+        public string? Uid { get; set; }
+
+        public string? Account { get; set; }
+
+        public string? Operator { get; set; }
+
         public string? Vin { get; set; }
 
         [DataType(DataType.Date)]

--- a/Views/PreviousSearches/Index.cshtml
+++ b/Views/PreviousSearches/Index.cshtml
@@ -8,6 +8,18 @@
         <label asp-for="RequestId" class="form-label"></label>
         <input asp-for="RequestId" class="form-control" />
     </div>
+    <div class="col-md-2">
+        <label asp-for="Uid" class="form-label"></label>
+        <input asp-for="Uid" class="form-control" />
+    </div>
+    <div class="col-md-2">
+        <label asp-for="Account" class="form-label"></label>
+        <input asp-for="Account" class="form-control" />
+    </div>
+    <div class="col-md-2">
+        <label asp-for="Operator" class="form-label"></label>
+        <input asp-for="Operator" class="form-control" />
+    </div>
     <div class="col-md-4">
         <label asp-for="Vin" class="form-label"></label>
         <input asp-for="Vin" class="form-control" />


### PR DESCRIPTION
## Summary
- extend PreviousSearches view model and view to support UID, account, and operator filters
- add optional UID, account, and operator parameters to PreviousSearches SQL query

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af5e00c4d8833088e6f107b2fa0859