### PR TITLE
Use environment configuration for connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# UCDASearches.WebMVC
+
+## Configuration
+
+The application retrieves its database connection string from configuration sources such as environment variables or [ASP.NET Core user secrets](https://learn.microsoft.com/aspnet/core/security/app-secrets).
+
+### Environment variable
+
+Set `ConnectionStrings__DefaultConnection` before running the app:
+
+```bash
+export ConnectionStrings__DefaultConnection="Server=SQL;Database=Searches;Trusted_Connection=True;MultipleActiveResultSets=true"
+```
+
+On Windows PowerShell use:
+
+```powershell
+$env:ConnectionStrings__DefaultConnection="Server=SQL;Database=Searches;Trusted_Connection=True;MultipleActiveResultSets=true"
+```
+
+### User secrets (development)
+
+From the project directory run:
+
+```bash
+# Initialize if this is the first time
+ dotnet user-secrets init
+ dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Server=SQL;Database=Searches;Trusted_Connection=True;MultipleActiveResultSets=true"
+```
+
+The connection string is retrieved in code with:
+
+```csharp
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+```
+
+This value is consumed, for example, by `PreviousSearchesController` when querying the database.
+

--- a/UCDASearches.WebMVC.csproj
+++ b/UCDASearches.WebMVC.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>b2b5b0cf-c734-4ab4-a510-89bf62e02395</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,8 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=SQLCLA;Database=Searches;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -5,8 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=SQLCLA;Database=Searches;Trusted_Connection=True;MultipleActiveResultSets=true"
-  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- remove hard-coded connection strings from appsettings files
- enable user secret storage with a project `UserSecretsId`
- add README instructions for configuring the connection string through environment variables or `dotnet user-secrets`

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68af5e02f22883309cfa2a5c04f6eb16