### PR TITLE
Fix mobile login page scaling

### DIFF
--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -7,6 +7,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Login - UCDASearches</title>
     <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
     <style>
@@ -18,6 +19,7 @@
             align-items: center;
             justify-content: center;
             font-family: Arial, sans-serif;
+            margin: 0;
         }
 
         .login-card {


### PR DESCRIPTION
## Summary
- add viewport meta tag and remove default body margin so the login form scales and centers on mobile devices

## Testing
- `dotnet build` *(fails: dotnet command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7523043708330a90d9eed905defab