### PR TITLE
Fix mobile login page scaling and update menu log out link

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -51,6 +51,13 @@ namespace UCDASearches.WebMVC.Controllers
             ModelState.AddModelError(string.Empty, "Invalid credentials");
             return View(model);
         }
+
+        [HttpGet]
+        public async Task<IActionResult> Logout()
+        {
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            return RedirectToAction("Login", "Account");
+        }
     }
 
     public class LoginViewModel

--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -7,6 +7,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Login - UCDASearches</title>
     <link href="~/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
     <style>
@@ -18,6 +19,7 @@
             align-items: center;
             justify-content: center;
             font-family: Arial, sans-serif;
+            margin: 0;
         }
 
         .login-card {

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -34,7 +34,7 @@
                     </ul>
                     <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-controller="Account" asp-action="Login">Sign in</a>
+                            <a class="nav-link" asp-area="" asp-controller="Account" asp-action="Logout">Log out</a>
                         </li>
                         <li class="nav-item ms-lg-3">
                             <a class="btn btn-primary" asp-area="" asp-controller="Search" asp-action="Index">New Search</a>


### PR DESCRIPTION
## Summary
- add viewport meta tag and remove default body margin so the login form scales and centers on mobile devices
- replace the navigation's sign-in link with a log out link and implement the corresponding controller action

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7523043708330a90d9eed905defab