### PR TITLE
Limit previous search filters to VIN and date

### DIFF
--- a/Controllers/PreviousSearchesController.cs
+++ b/Controllers/PreviousSearchesController.cs
@@ -28,8 +28,7 @@ public class PreviousSearchesController : Controller
         await using var connection = new SqlConnection(connectionString);
         await connection.OpenAsync();
 
-        bool hasFilters = !string.IsNullOrWhiteSpace(model.RequestId)
-                          || !string.IsNullOrWhiteSpace(model.Vin)
+        bool hasFilters = !string.IsNullOrWhiteSpace(model.Vin)
                           || model.Date.HasValue;
 
         var sb = new StringBuilder();
@@ -42,12 +41,6 @@ public class PreviousSearchesController : Controller
         await using var command = new SqlCommand();
         command.Connection = connection;
         command.Parameters.Add("@Account", SqlDbType.VarChar, 20).Value = DefaultAccount;
-
-        if (!string.IsNullOrWhiteSpace(model.RequestId))
-        {
-            sb.Append(" AND RequestID = @RequestID");
-            command.Parameters.Add("@RequestID", SqlDbType.Int).Value = int.Parse(model.RequestId);
-        }
 
         if (!string.IsNullOrWhiteSpace(model.Vin))
         {

--- a/Models/PreviousSearchesViewModel.cs
+++ b/Models/PreviousSearchesViewModel.cs
@@ -29,8 +29,6 @@ namespace UCDASearches.WebMVC.Models
 
     public class PreviousSearchesViewModel
     {
-        [Display(Name = "Request #")]
-        public string? RequestId { get; set; }
         public string? Vin { get; set; }
 
         [DataType(DataType.Date)]

--- a/Views/Account/Login.cshtml
+++ b/Views/Account/Login.cshtml
@@ -58,6 +58,7 @@
 </head>
 <body>
     <div class="login-card">
+        <img src="~/img/UCDA_sm.gif" alt="UCDASearches logo" class="img-fluid mx-auto d-block mb-3" style="max-width: 100px;" />
         <h4>Log in to UCDASearches</h4>
         <form method="post" asp-controller="Account" asp-action="Login">
             @Html.AntiForgeryToken()

--- a/Views/PreviousSearches/Index.Mobile.cshtml
+++ b/Views/PreviousSearches/Index.Mobile.cshtml
@@ -10,7 +10,6 @@
             <tr>
                 <th>Time</th>
                 <th>VIN</th>
-                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -19,9 +18,6 @@
             <tr>
                 <td>@item.TimeStamp.ToString("yyyy-MM-dd HH:mm:ss")</td>
                 <td>@item.Vin</td>
-                <td>
-                    <a asp-action="Index" asp-route-RequestId="@item.RequestID" class="btn btn-primary btn-sm">View</a>
-                </td>
             </tr>
         }
         </tbody>

--- a/Views/PreviousSearches/Index.cshtml
+++ b/Views/PreviousSearches/Index.cshtml
@@ -4,16 +4,11 @@
 }
 
 <form method="get" class="row g-3 mb-4">
-    <div class="col-md-2">
-        <label asp-for="RequestId" class="form-label"></label>
-        <input asp-for="RequestId" class="form-control" />
-    </div>
-
-    <div class="col-md-4">
+    <div class="col-md-6">
         <label asp-for="Vin" class="form-label"></label>
         <input asp-for="Vin" class="form-control" />
     </div>
-    <div class="col-md-2">
+    <div class="col-md-4">
         <label asp-for="Date" class="form-label"></label>
         <input asp-for="Date" class="form-control" />
     </div>


### PR DESCRIPTION
## Summary
- remove request ID filter from previous searches controller and model
- simplify search form to only accept VIN and date
- drop request ID link from mobile previous searches view
- add UCDA logo above login form heading

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c2b31e988330995e9645e67a1d8d