### PR TITLE
Add batch VIN submission page with province selector

### DIFF
--- a/Controllers/SearchController.cs
+++ b/Controllers/SearchController.cs
@@ -1,12 +1,16 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UCDASearches.WebMVC.Models;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace UCDASearches.WebMVC.Controllers
 {
     [Authorize]
     public class SearchController : Controller
     {
+        private static readonly List<SearchItem> _batchItems = new();
+
         [HttpGet("/search")]
         public IActionResult Index() => View(new SearchViewModel());
 
@@ -14,6 +18,57 @@ namespace UCDASearches.WebMVC.Controllers
         public IActionResult Index(SearchViewModel model)
         {
             // TODO: perform searches with submitted data
+            return View(model);
+        }
+
+        [HttpGet("/search/batch")]
+        public IActionResult Batch()
+        {
+            var model = new BatchSearchViewModel
+            {
+                Items = _batchItems
+            };
+            return View(model);
+        }
+
+        [HttpPost("/search/batch")]
+        public IActionResult Batch(BatchSearchViewModel model)
+        {
+            var vins = model.VinBatch?.Split('\n', '\r')
+                .Select(v => v.Trim())
+                .Where(v => !string.IsNullOrEmpty(v))
+                .Take(100)
+                ?? Enumerable.Empty<string>();
+
+            foreach (var vin in vins)
+            {
+                var existing = _batchItems.FirstOrDefault(i => i.Vin.Equals(vin, System.StringComparison.OrdinalIgnoreCase));
+                if (existing == null)
+                {
+                    existing = new SearchItem { Vin = vin, Province = model.Province };
+                    _batchItems.Add(existing);
+                }
+                else
+                {
+                    var provinces = existing.Province
+                        .Split(',', System.StringSplitOptions.RemoveEmptyEntries)
+                        .Select(p => p.Trim())
+                        .ToList();
+                    if (!provinces.Contains(model.Province, System.StringComparer.OrdinalIgnoreCase))
+                    {
+                        provinces.Add(model.Province);
+                        existing.Province = string.Join(", ", provinces);
+                    }
+                }
+
+                if (model.OntarioLien) existing.OntarioLien = true;
+                if (model.AutoCheck) existing.AutoCheck = true;
+                if (model.OntarioHistory) existing.OntarioHistory = true;
+                if (model.Oop) existing.Oop = true;
+            }
+
+            model.VinBatch = string.Empty;
+            model.Items = _batchItems;
             return View(model);
         }
     }

--- a/Models/BatchSearchViewModel.cs
+++ b/Models/BatchSearchViewModel.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace UCDASearches.WebMVC.Models
+{
+    public class BatchSearchViewModel
+    {
+        public string Province { get; set; } = "";
+        public string VinBatch { get; set; } = "";
+        public bool OntarioLien { get; set; }
+        public bool AutoCheck { get; set; }
+        public bool OntarioHistory { get; set; }
+        public bool Oop { get; set; }
+        public List<SearchItem> Items { get; set; } = new();
+        public IEnumerable<SelectListItem> Provinces { get; } = new List<SelectListItem>
+        {
+            new("Alberta", "AB"),
+            new("British Columbia", "BC"),
+            new("Manitoba", "MB"),
+            new("New Brunswick", "NB"),
+            new("Newfoundland and Labrador", "NL"),
+            new("Nova Scotia", "NS"),
+            new("Ontario", "ON"),
+            new("Prince Edward Island", "PE"),
+            new("Quebec", "QC"),
+            new("Saskatchewan", "SK"),
+            new("Northwest Territories", "NT"),
+            new("Nunavut", "NU"),
+            new("Yukon", "YT"),
+        };
+    }
+}

--- a/Models/SearchViewModel.cs
+++ b/Models/SearchViewModel.cs
@@ -6,6 +6,7 @@ namespace UCDASearches.WebMVC.Models
     public class SearchItem
     {
         public string Vin { get; set; } = "";
+        public string Province { get; set; } = "";
         public bool OntarioLien { get; set; }
         public bool AutoCheck { get; set; }
         public bool OntarioHistory { get; set; }

--- a/Views/Search/Batch.cshtml
+++ b/Views/Search/Batch.cshtml
@@ -1,0 +1,73 @@
+@model BatchSearchViewModel
+@{
+    ViewData["Title"] = "Batch Search";
+}
+<div class="row">
+    <div class="col-md-6">
+        <form asp-action="Batch" method="post">
+            <div class="mb-3">
+                <label asp-for="Province" class="form-label">Province</label>
+                <select asp-for="Province" class="form-select" asp-items="Model.Provinces"></select>
+            </div>
+            <div class="mb-3">
+                <label asp-for="VinBatch" class="form-label">VINs (one per line, up to 100)</label>
+                <textarea asp-for="VinBatch" class="form-control" rows="15"></textarea>
+            </div>
+            <div class="mb-3">
+                <div class="form-check">
+                    <input class="form-check-input" asp-for="OntarioLien" />
+                    <label class="form-check-label" asp-for="OntarioLien">Ontario Lien</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" asp-for="AutoCheck" />
+                    <label class="form-check-label" asp-for="AutoCheck">Auto Check</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" asp-for="OntarioHistory" />
+                    <label class="form-check-label" asp-for="OntarioHistory">Ontario History</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" asp-for="Oop" />
+                    <label class="form-check-label" asp-for="Oop">OOP</label>
+                </div>
+            </div>
+            <button class="btn btn-primary">Submit</button>
+        </form>
+    </div>
+    <div class="col-md-6">
+        <div class="border p-3" style="min-height:400px;">
+            @if (Model.Items.Count > 0)
+            {
+                <table class="table table-sm">
+                    <thead class="table-light">
+                        <tr>
+                            <th>VIN</th>
+                            <th>Province</th>
+                            <th>Ontario Lien</th>
+                            <th>Auto Check</th>
+                            <th>Ontario History</th>
+                            <th>OOP</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.Items)
+                        {
+                            <tr>
+                                <td>@item.Vin</td>
+                                <td>@item.Province</td>
+                                <td>@(item.OntarioLien ? "✔" : "")</td>
+                                <td>@(item.AutoCheck ? "✔" : "")</td>
+                                <td>@(item.OntarioHistory ? "✔" : "")</td>
+                                <td>@(item.Oop ? "✔" : "")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <p>No VINs submitted yet.</p>
+            }
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add province field to `SearchItem` model
- introduce `BatchSearchViewModel` and batch endpoints
- create batch search view with VIN textarea and province dropdown
- display only VIN, province, Ontario Lien, Auto Check, Ontario History, and OOP columns
- support comma-separated province abbreviations per VIN

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bed8347ad883309316dc189ec91241