### PR TITLE
Add batch VIN submission page with province selector

### DIFF
--- a/Controllers/SearchController.cs
+++ b/Controllers/SearchController.cs
@@ -1,12 +1,16 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using UCDASearches.WebMVC.Models;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace UCDASearches.WebMVC.Controllers
 {
     [Authorize]
     public class SearchController : Controller
     {
+        private static readonly List<SearchItem> _batchItems = new();
+
         [HttpGet("/search")]
         public IActionResult Index() => View(new SearchViewModel());
 
@@ -15,6 +19,73 @@ namespace UCDASearches.WebMVC.Controllers
         {
             // TODO: perform searches with submitted data
             return View(model);
+        }
+
+        [HttpGet("/search/batch")]
+        public IActionResult Batch()
+        {
+            var model = new BatchSearchViewModel
+            {
+                Items = _batchItems
+            };
+            return View(model);
+        }
+
+        [HttpPost("/search/batch")]
+        public IActionResult Batch(BatchSearchViewModel model)
+        {
+            var vins = model.VinBatch?.Split('\n', '\r')
+                .Select(v => v.Trim())
+                .Where(v => !string.IsNullOrEmpty(v))
+                .Take(100)
+                ?? Enumerable.Empty<string>();
+
+            foreach (var vin in vins)
+            {
+                var existing = _batchItems.FirstOrDefault(i => i.Vin.Equals(vin, System.StringComparison.OrdinalIgnoreCase));
+                if (existing == null)
+                {
+                    existing = new SearchItem { Vin = vin };
+                    _batchItems.Add(existing);
+                }
+
+                switch (model.SearchType)
+                {
+                    case "Lien":
+                        existing.OntarioLien = true;
+                        if (!string.IsNullOrEmpty(model.Province))
+                        {
+                            var provinces = existing.Province
+                                .Split(',', System.StringSplitOptions.RemoveEmptyEntries)
+                                .Select(p => p.Trim())
+                                .ToList();
+                            if (!provinces.Contains(model.Province, System.StringComparer.OrdinalIgnoreCase))
+                            {
+                                provinces.Add(model.Province);
+                                existing.Province = string.Join(", ", provinces);
+                            }
+                        }
+                        break;
+                    case "AutoCheck":
+                        existing.AutoCheck = true;
+                        break;
+                    case "OntarioHistory":
+                        existing.OntarioHistory = true;
+                        break;
+                }
+            }
+
+            model.VinBatch = string.Empty;
+            model.Province = string.Empty;
+            model.Items = _batchItems;
+            return View(model);
+        }
+
+        [HttpPost("/search/batch/clear")]
+        public IActionResult ClearBatch()
+        {
+            _batchItems.Clear();
+            return RedirectToAction(nameof(Batch));
         }
     }
 }

--- a/Models/BatchSearchViewModel.cs
+++ b/Models/BatchSearchViewModel.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace UCDASearches.WebMVC.Models
+{
+    public class BatchSearchViewModel
+    {
+        public string SearchType { get; set; } = "AutoCheck";
+        public string Province { get; set; } = "";
+        public string VinBatch { get; set; } = "";
+        public List<SearchItem> Items { get; set; } = new();
+        public IEnumerable<SelectListItem> SearchTypes { get; } = new List<SelectListItem>
+        {
+            new("AutoCheck", "AutoCheck"),
+            new("Lien", "Lien"),
+            new("Ontario History", "OntarioHistory"),
+        };
+        public IEnumerable<SelectListItem> Provinces { get; } = new List<SelectListItem>
+        {
+            new("Alberta", "AB"),
+            new("British Columbia", "BC"),
+            new("Manitoba", "MB"),
+            new("New Brunswick", "NB"),
+            new("Newfoundland and Labrador", "NL"),
+            new("Nova Scotia", "NS"),
+            new("Ontario", "ON"),
+            new("Prince Edward Island", "PE"),
+            new("Quebec", "QC"),
+            new("Saskatchewan", "SK"),
+            new("Northwest Territories", "NT"),
+            new("Nunavut", "NU"),
+            new("Yukon", "YT"),
+        };
+    }
+}

--- a/Models/SearchViewModel.cs
+++ b/Models/SearchViewModel.cs
@@ -6,6 +6,7 @@ namespace UCDASearches.WebMVC.Models
     public class SearchItem
     {
         public string Vin { get; set; } = "";
+        public string Province { get; set; } = "";
         public bool OntarioLien { get; set; }
         public bool AutoCheck { get; set; }
         public bool OntarioHistory { get; set; }

--- a/Views/Search/Batch.cshtml
+++ b/Views/Search/Batch.cshtml
@@ -1,0 +1,81 @@
+@model BatchSearchViewModel
+@{
+    ViewData["Title"] = "Batch Search";
+}
+<div class="row">
+    <div class="col-md-6">
+        <form asp-action="Batch" method="post">
+            <div class="mb-3">
+                <label asp-for="SearchType" class="form-label">Search Type</label>
+                <select asp-for="SearchType" class="form-select" asp-items="Model.SearchTypes" id="searchType"></select>
+            </div>
+            <div class="mb-3" id="provinceContainer">
+                <label asp-for="Province" class="form-label">Province</label>
+                <select asp-for="Province" class="form-select" asp-items="Model.Provinces"></select>
+            </div>
+            <div class="mb-3">
+                <label asp-for="VinBatch" class="form-label">VINs (one per line, up to 100)</label>
+                <textarea asp-for="VinBatch" class="form-control" rows="15"></textarea>
+            </div>
+            <button class="btn btn-primary">Submit</button>
+            <button type="reset" class="btn btn-secondary ms-2">Clear</button>
+        </form>
+    </div>
+    <div class="col-md-6">
+        <div class="d-flex justify-content-end mb-2">
+            <form asp-action="ClearBatch" method="post">
+                <button class="btn btn-secondary">Clear</button>
+            </form>
+        </div>
+        <div class="border p-3" style="min-height:400px;">
+            @if (Model.Items.Count > 0)
+            {
+                <table class="table table-sm">
+                    <thead class="table-light">
+                        <tr>
+                            <th>VIN</th>
+                            <th>Province</th>
+                            <th>Ontario Lien</th>
+                            <th>Auto Check</th>
+                            <th>Ontario History</th>
+                            <th>OOP</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.Items)
+                        {
+                            <tr>
+                                <td>@item.Vin</td>
+                                <td>@item.Province</td>
+                                <td>@(item.OntarioLien ? "✔" : "")</td>
+                                <td>@(item.AutoCheck ? "✔" : "")</td>
+                                <td>@(item.OntarioHistory ? "✔" : "")</td>
+                                <td>@(item.Oop ? "✔" : "")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            }
+            else
+            {
+                <p>No VINs submitted yet.</p>
+            }
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+<script>
+    const searchType = document.getElementById('searchType');
+    const provinceContainer = document.getElementById('provinceContainer');
+    function toggleProvince() {
+        if (searchType.value === 'Lien') {
+            provinceContainer.style.display = 'block';
+        } else {
+            provinceContainer.style.display = 'none';
+        }
+    }
+    searchType.addEventListener('change', toggleProvince);
+    toggleProvince();
+</script>
+}


### PR DESCRIPTION
## Summary
- replace search checkboxes with single dropdown of AutoCheck, Lien, and Ontario History options
- append province abbreviations only when Lien search selected and allow clearing stored VIN results
- add clear buttons for submission form and results list with conditional province dropdown display

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed8347ad883309316dc189ec91241