### PR TITLE
Remove unused options from batch search dropdown

### DIFF
--- a/Models/BatchSearchViewModel.cs
+++ b/Models/BatchSearchViewModel.cs
@@ -28,9 +28,6 @@ namespace UCDASearches.WebMVC.Models
             new("AutoCheck", "AutoCheck"),
             new("Lien", "Lien"),
             new("Ontario History", "OntarioHistory"),
-            new("OOP", "Oop"),
-            new("Carfax", "Carfax"),
-            new("Export Check", "ExportCheck"),
         };
 
         // Province list uses 2-letter codes as values


### PR DESCRIPTION
## Summary
- drop OOP, Carfax and Export Check from batch search-type dropdown

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3174a43c8330ad2567d5f4d32540